### PR TITLE
Experimental

### DIFF
--- a/src/food.ts
+++ b/src/food.ts
@@ -3,17 +3,17 @@ interface Coordinates {
     y: number
 }
 
-abstract class Food {
+export abstract class Food {
     static height = 10
     static width = 10
-    ctx: any
+    static ctx: CanvasRenderingContext2D
+    
     color: string
     coordinates: Coordinates
     x: number
     y: number
 
-    constructor(coordinates: Coordinates, ctx: RenderingContext){
-        this.ctx = ctx
+    constructor(coordinates: Coordinates){
         this.color = 'red'
         this.coordinates = coordinates
         this.x = coordinates.x
@@ -21,25 +21,25 @@ abstract class Food {
     }
 
     draw(){
-        this.ctx.fillStyle = this.color
-        this.ctx.fillRect(this.coordinates.x, this.coordinates.y, Food.height, Food.width)
+        Food.ctx.fillStyle = this.color
+        Food.ctx.fillRect(this.coordinates.x, this.coordinates.y, Food.height, Food.width)
     }
 }
 
 export class Pellet extends Food {
-    constructor(coordinates: Coordinates, ctx: RenderingContext){
-        super(coordinates, ctx)
+    constructor(coordinates: Coordinates){
+        super(coordinates)
         this.color = 'yellow'
     }
 
     draw(): void {
-        this.ctx.fillStyle = this.color
+        Food.ctx.fillStyle = this.color
 
-        this.ctx.rect(this.x - 2, this.y, 8, 4)
-        this.ctx.fill()
+        Food.ctx.rect(this.x - 2, this.y, 8, 4)
+        Food.ctx.fill()
 
-        this.ctx.rect(this.x, this.y - 2, 4, 8)
-        this.ctx.fill()
+        Food.ctx.rect(this.x, this.y - 2, 4, 8)
+        Food.ctx.fill()
 
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Pellet } from "./food.js"
+import { Food, Pellet } from "./food.js"
 import { BodySegment, Head, Snake } from "./snake.js"
 
 const canvas: HTMLCanvasElement = document.getElementById("canvas") as HTMLCanvasElement
@@ -21,7 +21,8 @@ async function sleep(timeMS: number): Promise<any> {
 // SNAKE CREATION ==============================================
 
 function createPlayer() {
-    Snake.setContext(ctx)
+    Food.ctx = ctx
+    Snake.ctx = ctx
 
     Snake.body = []
     Snake.setHead(new Head({ x: canvas.width / 2, y: canvas.height / 2 }))
@@ -31,7 +32,8 @@ function createPlayer() {
     }
 }
 createPlayer()
-const testFood = new Pellet({x: 100, y: 100}, ctx)
+
+const testFood = new Pellet({x: 100, y: 100})
 
 
 // KEY EVENTS ========================================

--- a/src/snake.ts
+++ b/src/snake.ts
@@ -33,11 +33,7 @@ export class Snake{
     static getSize() : number{
         return Snake.body.length
     }
-
-    static setContext(ctx: CanvasRenderingContext2D){
-        Snake.ctx = ctx
-    }
-
+    
 }
 
 abstract class Segment{


### PR DESCRIPTION
- Changes ctx into static value
- Changes ctx type from RenderingContext to CanvasRenderingContext2D, allowing code editors to  suggest 2d rendering context methods whenever ctx is called in a class.
- Removes the need to pass ctx as an argument everytime a Segment or Food subclass is instantiated

